### PR TITLE
Default bitmap for icons was Discord.bmp, changed to Disabled.bmp

### DIFF
--- a/src/ArduinoDeck.py
+++ b/src/ArduinoDeck.py
@@ -122,7 +122,7 @@ class MainPanel(wx.Panel):
 
 		self.padding = 70
 		self.edge = 35
-		bmp = wx.Bitmap(self.ImageDir+"Discord.bmp", wx.BITMAP_TYPE_ANY)
+		bmp = wx.Bitmap(self.ImageDir+"Disabled.bmp", wx.BITMAP_TYPE_ANY)
 
 		self.Button1 = buttons.GenBitmapToggleButton(self.ButtonPanel,bitmap=bmp,size=(bmp.GetWidth()+10, bmp.GetHeight()+10),style=wx.NO_BORDER,name="Button1")
 


### PR DESCRIPTION
On first run of a fresh clone was getting `Fatal Error: Failed to execute script ArduinoDeck`

The error was `Failed to load image from file "C:\arduino\deck\root\ArduinoDeck\ArduinoDeckIcons\Discord.bmp"` while loading `blank.json` layout. 